### PR TITLE
chore: remove @aws-cdk namespace from package name

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -11,7 +11,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,
-  packageName: '@aws-cdk/lambda-layer-awscli-v1',
+  packageName: 'lambda-layer-awscli-v1',
   workflowBootstrapSteps: [
     {
       name: 'Change permissions on /var/run/docker.sock',

--- a/API.md
+++ b/API.md
@@ -2,32 +2,32 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
-### AwsCliLayer <a name="AwsCliLayer" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer"></a>
+### AwsCliLayer <a name="AwsCliLayer" id="lambda-layer-awscli-v1.AwsCliLayer"></a>
 
 An AWS Lambda layer that includes the AWS CLI.
 
-#### Initializers <a name="Initializers" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.Initializer"></a>
+#### Initializers <a name="Initializers" id="lambda-layer-awscli-v1.AwsCliLayer.Initializer"></a>
 
 ```typescript
-import { AwsCliLayer } from '@aws-cdk/lambda-layer-awscli-v1'
+import { AwsCliLayer } from 'lambda-layer-awscli-v1'
 
 new AwsCliLayer(scope: Construct, id: string)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="lambda-layer-awscli-v1.AwsCliLayer.Initializer.parameter.id"></a>
 
 - *Type:* string
 
@@ -37,13 +37,13 @@ new AwsCliLayer(scope: Construct, id: string)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.addPermission">addPermission</a></code> | Add permission for this layer version to specific entities. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.addPermission">addPermission</a></code> | Add permission for this layer version to specific entities. |
 
 ---
 
-##### `toString` <a name="toString" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.toString"></a>
+##### `toString` <a name="toString" id="lambda-layer-awscli-v1.AwsCliLayer.toString"></a>
 
 ```typescript
 public toString(): string
@@ -51,7 +51,7 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy"></a>
+##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy"></a>
 
 ```typescript
 public applyRemovalPolicy(policy: RemovalPolicy): void
@@ -67,13 +67,13 @@ to be replaced.
 The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
 account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
 
-###### `policy`<sup>Required</sup> <a name="policy" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy.parameter.policy"></a>
+###### `policy`<sup>Required</sup> <a name="policy" id="lambda-layer-awscli-v1.AwsCliLayer.applyRemovalPolicy.parameter.policy"></a>
 
 - *Type:* aws-cdk-lib.RemovalPolicy
 
 ---
 
-##### `addPermission` <a name="addPermission" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.addPermission"></a>
+##### `addPermission` <a name="addPermission" id="lambda-layer-awscli-v1.AwsCliLayer.addPermission"></a>
 
 ```typescript
 public addPermission(id: string, permission: LayerVersionPermission): void
@@ -88,13 +88,13 @@ Lambda function using the layer (for example, a CloudFormation changeset
 execution role) also needs to have the ``lambda:GetLayerVersion``
 permission on the layer version.
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.addPermission.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="lambda-layer-awscli-v1.AwsCliLayer.addPermission.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `permission`<sup>Required</sup> <a name="permission" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.addPermission.parameter.permission"></a>
+###### `permission`<sup>Required</sup> <a name="permission" id="lambda-layer-awscli-v1.AwsCliLayer.addPermission.parameter.permission"></a>
 
 - *Type:* aws-cdk-lib.aws_lambda.LayerVersionPermission
 
@@ -104,24 +104,24 @@ permission on the layer version.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn">fromLayerVersionArn</a></code> | Imports a layer version by ARN. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes">fromLayerVersionAttributes</a></code> | Imports a Layer that has been defined externally. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn">fromLayerVersionArn</a></code> | Imports a layer version by ARN. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes">fromLayerVersionAttributes</a></code> | Imports a Layer that has been defined externally. |
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="lambda-layer-awscli-v1.AwsCliLayer.isConstruct"></a>
 
 ```typescript
-import { AwsCliLayer } from '@aws-cdk/lambda-layer-awscli-v1'
+import { AwsCliLayer } from 'lambda-layer-awscli-v1'
 
 AwsCliLayer.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
 
-###### `x`<sup>Required</sup> <a name="x" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isConstruct.parameter.x"></a>
+###### `x`<sup>Required</sup> <a name="x" id="lambda-layer-awscli-v1.AwsCliLayer.isConstruct.parameter.x"></a>
 
 - *Type:* any
 
@@ -129,26 +129,26 @@ Any object.
 
 ---
 
-##### `isResource` <a name="isResource" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isResource"></a>
+##### `isResource` <a name="isResource" id="lambda-layer-awscli-v1.AwsCliLayer.isResource"></a>
 
 ```typescript
-import { AwsCliLayer } from '@aws-cdk/lambda-layer-awscli-v1'
+import { AwsCliLayer } from 'lambda-layer-awscli-v1'
 
 AwsCliLayer.isResource(construct: IConstruct)
 ```
 
 Check whether the given construct is a Resource.
 
-###### `construct`<sup>Required</sup> <a name="construct" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.isResource.parameter.construct"></a>
+###### `construct`<sup>Required</sup> <a name="construct" id="lambda-layer-awscli-v1.AwsCliLayer.isResource.parameter.construct"></a>
 
 - *Type:* constructs.IConstruct
 
 ---
 
-##### `fromLayerVersionArn` <a name="fromLayerVersionArn" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn"></a>
+##### `fromLayerVersionArn` <a name="fromLayerVersionArn" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn"></a>
 
 ```typescript
-import { AwsCliLayer } from '@aws-cdk/lambda-layer-awscli-v1'
+import { AwsCliLayer } from 'lambda-layer-awscli-v1'
 
 AwsCliLayer.fromLayerVersionArn(scope: Construct, id: string, layerVersionArn: string)
 ```
@@ -157,35 +157,35 @@ Imports a layer version by ARN.
 
 Assumes it is compatible with all Lambda runtimes.
 
-###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.scope"></a>
+###### `scope`<sup>Required</sup> <a name="scope" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
 ---
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.id"></a>
 
 - *Type:* string
 
 ---
 
-###### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.layerVersionArn"></a>
+###### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionArn.parameter.layerVersionArn"></a>
 
 - *Type:* string
 
 ---
 
-##### `fromLayerVersionAttributes` <a name="fromLayerVersionAttributes" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes"></a>
+##### `fromLayerVersionAttributes` <a name="fromLayerVersionAttributes" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes"></a>
 
 ```typescript
-import { AwsCliLayer } from '@aws-cdk/lambda-layer-awscli-v1'
+import { AwsCliLayer } from 'lambda-layer-awscli-v1'
 
 AwsCliLayer.fromLayerVersionAttributes(scope: Construct, id: string, attrs: LayerVersionAttributes)
 ```
 
 Imports a Layer that has been defined externally.
 
-###### `scope`<sup>Required</sup> <a name="scope" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.scope"></a>
+###### `scope`<sup>Required</sup> <a name="scope" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
@@ -193,7 +193,7 @@ the parent Construct that will use the imported layer.
 
 ---
 
-###### `id`<sup>Required</sup> <a name="id" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.id"></a>
+###### `id`<sup>Required</sup> <a name="id" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.id"></a>
 
 - *Type:* string
 
@@ -201,7 +201,7 @@ the id of the imported layer in the construct tree.
 
 ---
 
-###### `attrs`<sup>Required</sup> <a name="attrs" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.attrs"></a>
+###### `attrs`<sup>Required</sup> <a name="attrs" id="lambda-layer-awscli-v1.AwsCliLayer.fromLayerVersionAttributes.parameter.attrs"></a>
 
 - *Type:* aws-cdk-lib.aws_lambda.LayerVersionAttributes
 
@@ -213,15 +213,15 @@ the properties of the imported layer.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.compatibleRuntimes">compatibleRuntimes</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime[]</code> | The runtimes compatible with this Layer. |
-| <code><a href="#@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.layerVersionArn">layerVersionArn</a></code> | <code>string</code> | The ARN of the Lambda Layer version that this Layer defines. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.property.compatibleRuntimes">compatibleRuntimes</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime[]</code> | The runtimes compatible with this Layer. |
+| <code><a href="#lambda-layer-awscli-v1.AwsCliLayer.property.layerVersionArn">layerVersionArn</a></code> | <code>string</code> | The ARN of the Lambda Layer version that this Layer defines. |
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.node"></a>
+##### `node`<sup>Required</sup> <a name="node" id="lambda-layer-awscli-v1.AwsCliLayer.property.node"></a>
 
 ```typescript
 public readonly node: Node;
@@ -233,7 +233,7 @@ The tree node.
 
 ---
 
-##### `env`<sup>Required</sup> <a name="env" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.env"></a>
+##### `env`<sup>Required</sup> <a name="env" id="lambda-layer-awscli-v1.AwsCliLayer.property.env"></a>
 
 ```typescript
 public readonly env: ResourceEnvironment;
@@ -252,7 +252,7 @@ that might be different than the stack they were imported into.
 
 ---
 
-##### `stack`<sup>Required</sup> <a name="stack" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.stack"></a>
+##### `stack`<sup>Required</sup> <a name="stack" id="lambda-layer-awscli-v1.AwsCliLayer.property.stack"></a>
 
 ```typescript
 public readonly stack: Stack;
@@ -264,7 +264,7 @@ The stack in which this resource is defined.
 
 ---
 
-##### `compatibleRuntimes`<sup>Optional</sup> <a name="compatibleRuntimes" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.compatibleRuntimes"></a>
+##### `compatibleRuntimes`<sup>Optional</sup> <a name="compatibleRuntimes" id="lambda-layer-awscli-v1.AwsCliLayer.property.compatibleRuntimes"></a>
 
 ```typescript
 public readonly compatibleRuntimes: Runtime[];
@@ -276,7 +276,7 @@ The runtimes compatible with this Layer.
 
 ---
 
-##### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="@aws-cdk/lambda-layer-awscli-v1.AwsCliLayer.property.layerVersionArn"></a>
+##### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="lambda-layer-awscli-v1.AwsCliLayer.property.layerVersionArn"></a>
 
 ```typescript
 public readonly layerVersionArn: string;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aws-cdk/lambda-layer-awscli-v1",
+  "name": "lambda-layer-awscli-v1",
   "repository": {
     "type": "git",
     "url": "git@github.com:cdklabs/awscdk-lambda-layer-awscli-v1.git"


### PR DESCRIPTION
The cdklabs publishing credentials do not have permission to publish under the @aws-cdk namespace. 