### PR TITLE
feat: add go publishing step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,3 +177,28 @@ jobs:
         run: cd .repo && npx projen package:dotnet
       - name: Collect dotnet Artifact
         run: mv .repo/dist dist
+  package-go:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,3 +198,36 @@ jobs:
         run: npx -p publib@latest publib-nuget
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14.x
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        run: npx -p publib@latest publib-golang
+        env:
+          GIT_USER_NAME: github-actions
+          GIT_USER_EMAIL: github-actions@github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,7 @@ queue_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
+      - status-success=package-go
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -29,3 +30,4 @@ pull_request_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
+      - status-success=package-go

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -226,6 +226,9 @@
         },
         {
           "spawn": "package:dotnet"
+        },
+        {
+          "spawn": "package:go"
         }
       ]
     },
@@ -235,6 +238,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target dotnet"
+        }
+      ]
+    },
+    "package:go": {
+      "name": "package:go",
+      "description": "Create go language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -37,7 +37,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   publishToGo: {
     moduleName: 'github.com/cdklabs/awscdk-asset-awscli-go',
-    packageName: 'v1',
+    packageName: 'awscdkv1',
   },
 });
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -35,6 +35,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
     dotNetNamespace: 'Amazon.CDK.Asset.AwsCliV1',
     packageId: 'Amazon.CDK.Asset.AwsCliV1',
   },
+  publishToGo: {
+    moduleName: 'github.com/cdklabs/awscdk-asset-awscli-go',
+  },
 });
 
 // These patches are required to enable sudo commands in the workflows under `workflowBootstrapSteps`,

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -37,7 +37,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   publishToGo: {
     moduleName: 'github.com/cdklabs/awscdk-asset-awscli-go',
-    packageName: 'awscdkv1',
+    packageName: 'awscliv1',
   },
 });
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -37,6 +37,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   publishToGo: {
     moduleName: 'github.com/cdklabs/awscdk-asset-awscli-go',
+    packageName: 'v1',
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
         "packageId": "Amazon.CDK.Asset.AwsCliV1"
       },
       "go": {
-        "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go"
+        "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go",
+        "packageName": "v1"
       }
     },
     "tsc": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
       },
       "go": {
         "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go",
-        "packageName": "awscdkv1"
+        "packageName": "awscliv1"
       }
     },
     "tsc": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
       },
       "go": {
         "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go",
-        "packageName": "v1"
+        "packageName": "awscdkv1"
       }
     },
     "tsc": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
+    "package:go": "npx projen package:go",
     "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
@@ -142,6 +143,9 @@
       "dotnet": {
         "namespace": "Amazon.CDK.Asset.AwsCliV1",
         "packageId": "Amazon.CDK.Asset.AwsCliV1"
+      },
+      "go": {
+        "moduleName": "github.com/cdklabs/awscdk-asset-awscli-go"
       }
     },
     "tsc": {


### PR DESCRIPTION
The import for this should look something like:

```go
import "github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2"
```

It's not ideal, in particular exposing "cdklabs", but it's what we have to work with. Publishing directly to aws-cdk-go is not an option, because it is version locked with aws-cdk. 

