### PR TITLE
chore: allow aws-cdk-automation auto approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'cdklabs-automation')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'aws-cdk-automation')
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -14,7 +14,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   repositoryUrl: 'https://github.com/cdklabs/awscdk-asset-awscli.git',
   homepage: 'https://github.com/cdklabs/awscdk-asset-awscli#readme',
   autoApproveOptions: {
-    allowedUsernames: ['cdklabs-automation'],
+    allowedUsernames: ['aws-cdk-automation'],
     secret: 'GITHUB_TOKEN',
   },
   autoApproveUpgrades: true,


### PR DESCRIPTION
This will allow our deps upgrade to be auto-approved / merged.