### PR TITLE
chore: upgrade workflow for aws-cli Dockerfile dependency

### DIFF
--- a/.github/scripts/upgrade-awscli-version.py
+++ b/.github/scripts/upgrade-awscli-version.py
@@ -1,0 +1,25 @@
+import subprocess
+import semver
+
+# pull the data from dockerhub
+data = subprocess.Popen(('curl', '-L', '-s', 'https://registry.hub.docker.com/v2/repositories/amazon/aws-cli/tags?page_size=100'), stdout=subprocess.PIPE)
+# query for only tags
+tagbytes = subprocess.check_output(('jq', '.results[].name'), stdin=data.stdout)
+data.wait()
+
+tags = tagbytes.decode("utf-8").replace('"','').split('\n')
+# trusting that tags are coming back in order from newest to oldest
+# we could go through all tags that come but I trust this assumption
+# some tags are 'latest' and 'amd64', so not valid semver. we skip these.
+latest_version = ''
+for tag in tags:
+  try:
+    semver.VersionInfo.parse(tag)
+    latest_version = tag
+    break
+  except ValueError:
+    continue
+
+# sed Dockerfile with new version
+# if its the same version, then no changes should happen
+subprocess.Popen(('sed', '-i', '', '-e', "/amazon\\/aws-cli:/s/:.*/:%s/"%(latest_version), 'layer/Dockerfile'), stdout=subprocess.PIPE)

--- a/.github/workflows/custom-upgrade-awscli-v2-main.yml
+++ b/.github/workflows/custom-upgrade-awscli-v2-main.yml
@@ -1,0 +1,91 @@
+name: custom-upgrade-awscli-v2-main
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  upgrade:
+    name: Upgrade
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      patch_created: ${{ steps.create_patch.outputs.patch_created }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: awscli-v2/main
+      - name: Change permissions on /var/run/docker.sock
+        run: sudo chown superchain /var/run/docker.sock
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
+      - name: Install Python Script Dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y jq
+          pip install semver
+      - name: Check for awscli version upgrades
+        run: python3 .github/scripts/upgrade-awscli-version.py
+      - id: create_patch
+        name: Find mutations
+        run: |-
+          git add .
+          git diff --staged --patch --exit-code > .repo.patch || echo "::set-output name=patch_created::true"
+      - if: steps.create_patch.outputs.patch_created
+        name: Upload patch
+        uses: actions/upload-artifact@v2
+        with:
+          name: .repo.patch
+          path: .repo.patch
+    container:
+      image: jsii/superchain:1-buster-slim-node14
+      options: --group-add sudo
+  pr:
+    name: Create Pull Request
+    needs: upgrade
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: ${{ needs.upgrade.outputs.patch_created }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: awscli-v2/main
+      - name: Download patch
+        uses: actions/download-artifact@v3
+        with:
+          name: .repo.patch
+          path: ${{ runner.temp }}
+      - name: Apply patch
+        run: '[ -s ${{ runner.temp }}/.repo.patch ] && git apply ${{ runner.temp }}/.repo.patch || echo "Empty patch. Skipping."'
+      - name: Set git identity
+        run: |-
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: |-
+            chore(deps): upgrade dependencies
+
+            Upgrades project dependencies. See details in [workflow run].
+
+            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          branch: github-actions/upgrade-awscli-v2-main
+          title: "chore(deps): upgrade aws-cli dependency"
+          labels: auto-approve
+          body: |-
+            Upgrades project dependencies. See details in [workflow run].
+
+            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          author: github-actions <github-actions@github.com>
+          committer: github-actions <github-actions@github.com>
+          signoff: true


### PR DESCRIPTION
I developed this in my fork; the result of this workflow will be a PR that looks like [this](https://github.com/kaizencc/awscdk-asset-awscli/pull/2).

Most of the github workflow is ripped from the `upgrade-awscli-v2-main` workflow, except that this replaces the projen step:

```yml
      - name: Install Python Script Dependencies
        run: |
          sudo apt update
          sudo apt install -y jq
          pip install semver
      - name: Check for awscli version upgrades
        run: python3 .github/scripts/upgrade-awscli-version.py
``` 

Upon merging, this should immediately introduce a PR that upgrades the aws-cli dep to 2.9.0.