### PR TITLE
chore: change upgrade v2 workflow github token

### DIFF
--- a/.github/workflows/custom-upgrade-awscli-v2-main.yml
+++ b/.github/workflows/custom-upgrade-awscli-v2-main.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: awscli-v2/main
       - name: Download patch
         uses: actions/download-artifact@v3
@@ -70,7 +70,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
             chore(deps): upgrade dependencies
             Upgrades project dependencies. See details in [workflow run].


### PR DESCRIPTION
Should result in the PR being cut by aws-cdk-automation and not github-actions