### PR TITLE
chore: only release on functional updates (v1)

### DIFF
--- a/.github/workflows/upgrade-awscli-v1-main.yml
+++ b/.github/workflows/upgrade-awscli-v1-main.yml
@@ -70,7 +70,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 
@@ -81,7 +81,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 

--- a/.github/workflows/upgrade-awscli-v2-main.yml
+++ b/.github/workflows/upgrade-awscli-v2-main.yml
@@ -70,7 +70,7 @@ jobs:
 
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 
@@ -81,7 +81,7 @@ jobs:
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 

--- a/.github/workflows/upgrade-cdklabs-projen-project-types-awscli-v1-main.yml
+++ b/.github/workflows/upgrade-cdklabs-projen-project-types-awscli-v1-main.yml
@@ -66,7 +66,7 @@ jobs:
 
             Upgrades cdklabs-projen-project-types dependency. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 
@@ -77,7 +77,7 @@ jobs:
           body: |-
             Upgrades cdklabs-projen-project-types dependency. See details in [workflow run].
 
-            [Workflow Run]: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            [Workflow Run]: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
             ------
 

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -32,7 +32,8 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": "awscli-v1"
+        "RELEASE_TAG_PREFIX": "awscli-v1",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
       },
       "steps": [
         {
@@ -336,7 +337,8 @@
         "CHANGELOG": "dist/changelog.md",
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
-        "RELEASE_TAG_PREFIX": "awscli-v1"
+        "RELEASE_TAG_PREFIX": "awscli-v1",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
       },
       "steps": [
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,5 +1,5 @@
 import { CdklabsConstructLibrary } from 'cdklabs-projen-project-types';
-import { DependencyType } from 'projen';
+import { DependencyType, ReleasableCommits } from 'projen';
 
 const MAJOR_VERSION = 1;
 const releaseWorkflowName = `release-awscli-v${MAJOR_VERSION}`;
@@ -35,6 +35,9 @@ const project = new CdklabsConstructLibrary({
   releaseTagPrefix: `awscli-v${MAJOR_VERSION}`,
   releaseWorkflowName: releaseWorkflowName,
   defaultReleaseBranch: defaultReleaseBranchName,
+  // If we don't do this we release the devDependency updates that happen every day, which blows out
+  // our PyPI storage budget even though there aren't any functional changes.
+  releasableCommits: ReleasableCommits.featuresAndFixes(),
   workflowNodeVersion: '16.x',
   minNodeVersion: '16.0.0',
   jsiiVersion: '^5',

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jsii-pacmak": "^1.84.0",
     "jsii-rosetta": "^5",
     "npm-check-updates": "^16",
-    "projen": "^0.71.103",
+    "projen": "^0.71.124",
     "standard-version": "^9",
     "ts-jest": "^29",
     "ts-node": "^10.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5210,6 +5210,25 @@ projen@^0.71.103:
     yaml "^2.2.2"
     yargs "^17.7.2"
 
+projen@^0.71.124:
+  version "0.71.124"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.71.124.tgz#94823d7af5842f0ca6692f9f2464d90edfd525d0"
+  integrity sha512-XSS+A46RyP140kBfIewMO8Qym2g2o5/F+ntIQZ3kSsGe2vTEvUk63LauqkMzIv2StTwCv/6veRjIriXmdEwsMg==
+  dependencies:
+    "@iarna/toml" "^2.2.5"
+    case "^1.6.3"
+    chalk "^4.1.2"
+    comment-json "4.2.2"
+    conventional-changelog-config-spec "^2.1.0"
+    fast-json-patch "^3.1.1"
+    glob "^8"
+    ini "^2.0.0"
+    semver "^7.5.3"
+    shx "^0.3.4"
+    xmlbuilder2 "^3.1.1"
+    yaml "^2.2.2"
+    yargs "^17.7.2"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -5590,6 +5609,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We currently release this package every day, which is blowing out our PyPI budget, but there's no need to. The actual CLI version doesn't change that often.

Fixes #