### PR TITLE
chore: use pipx to install instead of pip

### DIFF
--- a/.github/workflows/custom-upgrade-awscli-v2-main.yml
+++ b/.github/workflows/custom-upgrade-awscli-v2-main.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y jq
-          pip install semver
+          pipx install semver
       - name: Check for awscli version upgrades
         run: python3 .github/scripts/upgrade-awscli-version.py
       - id: create_patch


### PR DESCRIPTION
Because of https://github.com/aws/jsii/pull/4219/files in the new superchain image.