### PR TITLE
chore: pipx ensurepath

### DIFF
--- a/.github/workflows/custom-upgrade-awscli-v2-main.yml
+++ b/.github/workflows/custom-upgrade-awscli-v2-main.yml
@@ -25,6 +25,7 @@ jobs:
           sudo apt update
           sudo apt install -y jq
           pipx install semver
+          pipx ensurepath
       - name: Check for awscli version upgrades
         run: python3 .github/scripts/upgrade-awscli-version.py
       - id: create_patch


### PR DESCRIPTION
```
installing semver...
⚠️  Note: '/github/home/.local/bin' is not on your PATH environment variable.
    These apps will not be globally accessible until your PATH is updated. Run
    `pipx ensurepath` to automatically add it, or manually modify your PATH in
    your shell's config file (i.e. ~/.bashrc).
```