### PR TITLE
chore: fix custom upgrade workflow

### DIFF
--- a/.github/workflows/custom-upgrade-awscli-v2-main.yml
+++ b/.github/workflows/custom-upgrade-awscli-v2-main.yml
@@ -28,7 +28,7 @@ jobs:
         run: | 
           cd .github/scripts
           python3 -m venv .venv
-          source .venv/bin/activate
+          . .venv/bin/activate
           pip install -r requirements.txt
           python3 upgrade-awscli-version.py
       - id: create_patch


### PR DESCRIPTION
`source` does not exist in `sh` shell