### PR TITLE
fix: update to AWS CLI 1.32.*

### DIFF
--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sam/build-python3.7
+FROM public.ecr.aws/sam/build-python3.8
 
 RUN mkdir -p /opt
 WORKDIR /tmp


### PR DESCRIPTION
The new AWS CLI requires Python 3.8.

The custom resources that actually use this layer all pick Python 3.9 or higher.
