### PR TITLE
chore: fix the script upgrading the aws cli version

### DIFF
--- a/.github/scripts/upgrade-awscli-version.py
+++ b/.github/scripts/upgrade-awscli-version.py
@@ -1,5 +1,6 @@
-import subprocess
+import re
 import semver
+import subprocess
 
 # pull the data from dockerhub
 data = subprocess.Popen(('curl', '-L', '-s', 'https://registry.hub.docker.com/v2/repositories/amazon/aws-cli/tags?page_size=100'), stdout=subprocess.PIPE)
@@ -20,6 +21,10 @@ for tag in tags:
   except ValueError:
     continue
 
-# sed Dockerfile with new version
-# if its the same version, then no changes should happen
-subprocess.check_call(('sed', '-i', '', '-e', "/amazon\\/aws-cli:/s/:.*/:%s/"%(latest_version), '../../layer/Dockerfile'), stdout=subprocess.PIPE)
+dockerfile_path = '../../layer/Dockerfile'
+pattern_compiled = re.compile(r"^(FROM amazon/aws-cli:).*")
+with open(dockerfile_path, "r") as dockerfile:
+  lines = dockerfile.readlines()
+with open(dockerfile_path, "w") as sources:
+  for line in lines:
+    sources.write(re.sub(pattern_compiled, r'\g<1>'+latest_version, line))


### PR DESCRIPTION
This was previously using sed. Which is fine, but sed behaves differently on Linux and macOs. So I wasted a bunch of time trying to understand why it's working locally but not in GitHub Action. Having scripts behave differently in different environments isn't great. So instead of fixing the sed command, this is now using python only.
