### PR TITLE
chore: update python image version

### DIFF
--- a/layer/Dockerfile
+++ b/layer/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sam/build-python3.8
+FROM public.ecr.aws/sam/build-python3.11
 
 RUN mkdir -p /opt
 WORKDIR /tmp


### PR DESCRIPTION
Fixes current dependency upgrade issue for aws-cli version as CLI ended support for version 3.8
Ref: https://pypi.org/project/awscli/

```
On 2025-04-22, support for Python 3.8 ended for the AWS CLI.
```
Build failure: https://github.com/cdklabs/awscdk-asset-awscli/actions/runs/14784691302/job/41510899316?pr=1211

Error details:
#10 [ 6/13] RUN python -m pip install -r requirements.txt -t /opt/awscli
#10 1.208 ERROR: Ignored the following versions that require a different python version: 1.39.0 Requires-Python >=3.9; 1.40.0 Requires-Python >=3.9; 1.40.1 Requires-Python >=3.9; 1.40.2 Requires-Python >=3.9; 1.40.3 Requires-Python >=3.9; 1.40.4 Requires-Python >=3.9; 1.40.5 Requires-Python >=3.9; 1.40.6 Requires-Python >=3.9

**Note: Tried updating the version to 3.12 but it fails the installation for yum command hence updated to next latest 3.11**