### PR TITLE
chore: turn off trusted publishing for NuGet

### DIFF
--- a/.github/workflows/release-awscli-v1.yml
+++ b/.github/workflows/release-awscli-v1.yml
@@ -226,7 +226,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
@@ -260,8 +259,7 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          NUGET_TRUSTED_PUBLISHER: "true"
-          NUGET_USERNAME: ${{ secrets.NUGET_USERNAME }}
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: npx -p publib@latest publib-nuget
   release_golang:
     name: Publish to GitHub Go Module Repository

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,7 @@ const project = new CdklabsConstructLibrary({
   },
   publishToNuget: {
     // Trying to turn off trusted publishing default for NuGet package
-    trustedPublishing: "false",
+    trustedPublishing: 'false',
     dotNetNamespace: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
     packageId: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
   },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,7 @@ const project = new CdklabsConstructLibrary({
   },
   publishToNuget: {
     // Trying to turn off trusted publishing default for NuGet package
-    trustedPublishing: '',
+    trustedPublishing: "",
     dotNetNamespace: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
     packageId: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
   },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,7 @@ const project = new CdklabsConstructLibrary({
   },
   publishToNuget: {
     // Trying to turn off trusted publishing default for NuGet package
-    trustedPublishing: "",
+    trustedPublishing: "false",
     dotNetNamespace: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
     packageId: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
   },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,6 +51,8 @@ const project = new CdklabsConstructLibrary({
     mavenServerId: 'central-ossrh',
   },
   publishToNuget: {
+    // Trying to turn off trusted publishing default for NuGet package
+    trustedPublishing: '',
     dotNetNamespace: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
     packageId: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
   },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,7 @@ const project = new CdklabsConstructLibrary({
   },
   publishToNuget: {
     // Trying to turn off trusted publishing default for NuGet package
-    trustedPublishing: 'false',
+    trustedPublishing: false,
     dotNetNamespace: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
     packageId: `Amazon.CDK.Asset.AwsCliV${MAJOR_VERSION}`,
   },


### PR DESCRIPTION
Fixes #

Turns off trusted publishing for Nuget

This required : 
-  changing publib to handle false flag : https://github.com/cdklabs/publib/pull/1755, 
- running projen types upgrade to ensure release file was proper : https://github.com/cdklabs/publib/actions/workflows/upgrade-cdklabs-projen-project-types-main.yml
- Also required the dependent changes here : https://github.com/cdklabs/cdklabs-projen-project-types/pull/887 to ensure that all branches passed to projen `UpgradeCdklabsProjenProjectTypes` are honoured properly